### PR TITLE
Remove Google analytics

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -129,24 +129,6 @@ module.exports = {
       },
     },
     {
-      resolve: `gatsby-plugin-google-gtag`,
-      options: {
-        trackingIds: ["UA-122108242-1"],
-
-        gtagConfig: {
-          optimize_id: "GTM-MNBLGN7",
-          anonymize_ip: true,
-          cookie_expires: 0,
-        },
-
-        pluginConfig: {
-          head: false,
-          respectDNT: true,
-          exclude: ["/preview/**", "/do-not-track/me/too/"],
-        },
-      },
-    },
-    {
       resolve: `gatsby-plugin-manifest`,
       options: {
         name: SITE_NAME,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "gatsby-link": "2.2.18",
     "gatsby-plugin-emotion": "4.1.9",
     "gatsby-plugin-feed": "2.3.15",
-    "gatsby-plugin-google-gtag": "1.1.11",
     "gatsby-plugin-manifest": "2.2.20",
     "gatsby-plugin-mdx": "1.0.49",
     "gatsby-plugin-offline": "3.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5782,14 +5782,6 @@ gatsby-plugin-feed@2.3.15:
     lodash.merge "^4.6.2"
     rss "^1.2.2"
 
-gatsby-plugin-google-gtag@1.1.11:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-google-gtag/-/gatsby-plugin-google-gtag-1.1.11.tgz#ee1ca19e880b844083214e42e720ba41da969c0d"
-  integrity sha512-JGGoCsD7RydCUH7SAScrrDjeEvrEWxzTTZE41/9M4et5Kq6mF7z7AQLNeSv9Iz2jHvDrYX6+UeX+6tASy8ce0g==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    minimatch "^3.0.4"
-
 gatsby-plugin-manifest@2.2.20:
   version "2.2.20"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.2.20.tgz#67fa1d6335846097364c2eceece5a4bdc326706e"


### PR DESCRIPTION
Mostly out of curiosity for build size improvements, but also Netlify analytics might be able to provide adequate insights.