### PR TITLE
Update Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,5 +7,6 @@
       "schedule": ["every weekend"]
     }
   ],
+  "schedule": ["after 5pm and before 6am on every weekday", "every weekend"],
   "rebaseStalePrs": true
 }


### PR DESCRIPTION
Set wider scheduling rules for renovate and move it to the .github config folder